### PR TITLE
Update @carbon/icons-angular import

### DIFF
--- a/projects/carbonicons-angular-ngcc/src/app/app.module.ts
+++ b/projects/carbonicons-angular-ngcc/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
-import '@carbon/icons-angular';
+import { Download20Module } from '@carbon/icons-angular/lib/download/20';
 
 import { AppComponent } from './app.component';
 
@@ -10,7 +10,8 @@ import { AppComponent } from './app.component';
     AppComponent
   ],
   imports: [
-    BrowserModule
+    BrowserModule,
+    Download20Module,
   ],
   providers: [],
   bootstrap: [AppComponent]


### PR DESCRIPTION
The `@carbon/icons-angular` package does not conform to APF and does not
have a source file at the supposed entry-point root of
`@carbon/icons-angular`. Therefore, the build error
`Module not found: Error: Can't resolve '@carbon/icons-angular'` would
occur.

This updates the import to an actual location, as documented by Carbon's
documentation. The package will still fail to compile, however, as ngcc
seems not to process the entry-point at all.