### PR TITLE
Date fn versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "chart.js": "^2.7.3",
     "datatables.net": "^1.10.19",
     "date-fns": "^1.30.1",
+    "date-fns-2.x": "npm:date-fns@2.4.1",
     "devextreme": "~19.1.4",
     "devextreme-angular": "19.1.5",
     "echarts": ">=3.1.1",

--- a/projects/nebulardate-fns-ngcc/tsconfig.app.json
+++ b/projects/nebulardate-fns-ngcc/tsconfig.app.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/app",
-    "types": []
+    "types": [],
+    "baseUrl": "../..",
+    "paths": {
+      "date-fns/*": ["node_modules/date-fns-2.x/*"]
+    }
   },
   "files": [
     "src/main.ts",

--- a/projects/nebulardate-fns-ngcc/tsconfig.spec.json
+++ b/projects/nebulardate-fns-ngcc/tsconfig.spec.json
@@ -5,7 +5,11 @@
     "types": [
       "jasmine",
       "node"
-    ]
+    ],
+    "baseUrl": "../..",
+    "paths": {
+      "date-fns/*": ["node_modules/date-fns-2.x/*"]
+    }
   },
   "files": [
     "src/test.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5364,6 +5364,11 @@ datatables.net@^1.10.19:
   dependencies:
     jquery ">=1.7"
 
+"date-fns-2.x@npm:date-fns@2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.4.1.tgz#b53f9bb65ae6bd9239437035710e01cf383b625e"
+  integrity sha512-2RhmH/sjDSCYW2F3ZQxOUx/I7PvzXpi89aQL2d3OAxSTwLx6NilATeUbe0menFE3Lu5lFkOFci36ivimwYHHxw==
+
 date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"


### PR DESCRIPTION
Fix a conflict between two packages that need different major versions of the `date-fns` package as peer dependencies.