### PR TITLE
ui-router/angular-hybrid: fix e2e tests

### DIFF
--- a/projects/uirouterangular-hybrid-ngcc/e2e/src/app.e2e-spec.ts
+++ b/projects/uirouterangular-hybrid-ngcc/e2e/src/app.e2e-spec.ts
@@ -8,9 +8,15 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('uirouterangular-hybrid-ngcc app is running!');
+  it('should display a link to a route', async () => {
+    await page.navigateTo();
+    expect(page.getAnchor()).toEqual('Link to Angular child route using UIRouterUpgradeModule.forChild');
+  });
+
+  it('should navigate to a route', async () => {
+    await page.navigateTo();
+    await page.clickAnchor();
+    expect(page.getChildMessage()).toEqual('This is the child view');
   });
 
   afterEach(async () => {

--- a/projects/uirouterangular-hybrid-ngcc/e2e/src/app.po.ts
+++ b/projects/uirouterangular-hybrid-ngcc/e2e/src/app.po.ts
@@ -1,11 +1,20 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo() {
+  async navigateTo() {
+    await browser.waitForAngularEnabled(false);
     return browser.get(browser.baseUrl) as Promise<any>;
   }
 
-  getTitleText() {
-    return element(by.css('app-root .content span')).getText() as Promise<string>;
+  getAnchor() {
+    return element(by.css('a')).getText() as Promise<string>;
+  }
+
+  async clickAnchor() {
+    await element(by.css('a')).click();
+  }
+
+  getChildMessage() {
+    return element(by.css('p#child')).getText(); 
   }
 }

--- a/projects/uirouterangular-hybrid-ngcc/src/app/child.component.html
+++ b/projects/uirouterangular-hybrid-ngcc/src/app/child.component.html
@@ -1,1 +1,1 @@
-<p>This is the forChild</p>
+<p id="child">This is the child view</p>


### PR DESCRIPTION
Even once the compiler is fixed for this package, the e2e tests were
failing because they were boilerplate. They need special ngUpgrade
settings and were not testing the actual application.