### PR TITLE
tweak the covalent test app

### DIFF
--- a/infra/failing-projects.json
+++ b/infra/failing-projects.json
@@ -2,7 +2,6 @@
   "angular-froala-wysiwyg-ngcc",
   "angularx-social-login-ngcc",
   "carbonicons-angular-ngcc",
-  "covalentcore-ngcc",
   "harborui-ngcc",
   "nativescript-angular-ngcc",
   "ng2-pdfjs-viewer-ngcc",

--- a/projects/covalentcore-ngcc/src/app/app.module.ts
+++ b/projects/covalentcore-ngcc/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-
-import '@covalent/core';
+import { CovalentLayoutModule } from '@covalent/core/layout';
+import { CovalentStepsModule  } from '@covalent/core/steps';
 
 import { AppComponent } from './app.component';
 
@@ -10,7 +10,9 @@ import { AppComponent } from './app.component';
     AppComponent
   ],
   imports: [
-    BrowserModule
+    BrowserModule,
+    CovalentLayoutModule,
+    CovalentStepsModule,
   ],
   providers: [],
   bootstrap: [AppComponent]


### PR DESCRIPTION
Importing from the root entry-point does not seem to be
the recommended approach from looking at their docs.

The problem with doing this, is that the root package is
basically a concatenation of all the secondary entry-points
but uses the same typings files as the secondary entry-points.
This results in ngcc trying to write to the typings files twice.