### PR TITLE
test(@progress/kendo-angular-ripple): reduce flakiness in test

### DIFF
--- a/projects/kendo-ui-ripple-ngcc/e2e/src/app.e2e-spec.ts
+++ b/projects/kendo-ui-ripple-ngcc/e2e/src/app.e2e-spec.ts
@@ -8,10 +8,21 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('adds ripple overlay on button click', async() => {
-    page.navigateTo();
-    await page.getButtonAt(0).click();
-    expect(await page.getRippleOverlay().isPresent()).toBe(true);
+  it('adds ripple overlay on button click', async () => {
+    const firstButton = page.getButtonAt(0);
+    const secondButton = page.getButtonAt(1);
+
+    await page.navigateTo();
+    expect(page.isRippleTarget(firstButton)).toBe(false);
+    expect(page.isRippleTarget(secondButton)).toBe(false);
+
+    await firstButton.click();
+    expect(page.isRippleTarget(firstButton)).toBe(true);
+    expect(page.isRippleTarget(secondButton)).toBe(false);
+
+    await secondButton.click();
+    expect(page.isRippleTarget(firstButton)).toBe(false);
+    expect(page.isRippleTarget(secondButton)).toBe(true);
   });
 
   afterEach(async () => {

--- a/projects/kendo-ui-ripple-ngcc/e2e/src/app.po.ts
+++ b/projects/kendo-ui-ripple-ngcc/e2e/src/app.po.ts
@@ -1,4 +1,4 @@
-import { browser, by, element } from 'protractor';
+import { browser, by, element, ElementFinder } from 'protractor';
 
 export class AppPage {
   navigateTo() {
@@ -6,10 +6,11 @@ export class AppPage {
   }
 
   getButtonAt(index: number) {
-    return element(by.css('app-root button'));
+    return element.all(by.css('app-root button')).get(index);
   }
 
-  getRippleOverlay() {
-    return element(by.css('app-root .k-ripple'));
+  async isRippleTarget(elem: ElementFinder) {
+    const classes = (await elem.getAttribute('class')).split(' ');
+    return classes.indexOf('k-ripple-target') !== -1;
   }
 }


### PR DESCRIPTION
The previous e2e test for `@progress/kendo-angular-ripple` was flaky, because it relied on capturing the presence of the temporary ripple overlay element. Example failures:
- https://circleci.com/gh/angular/ngcc-validation/2360
- https://circleci.com/gh/angular/ngcc-validation/2368

This commit reduces the flakiness of the test by relying on detecting a different feature (the ripple target), which will not change until another element gains focus (so it is not susceptible to race conditions, unlike the ripple overlay).