### PR TITLE
test: Kendo UI Grid filtering with Ivy

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "ag-grid-community": "^22.0.0",
     "angular": "^1.7.8",
     "angular-2-dropdown-multiselect": "1.9.0",
-    "angular-bootstrap-datetimepicker": "4.0.2",
     "angular-calendar": "0.28.2",
     "angular-datatables": "8.0.0",
     "angular-draggable-droppable": "4.3.8",

--- a/projects/kendo-ui-i18n-ngcc/src/locale/messages.es.xlf
+++ b/projects/kendo-ui-i18n-ngcc/src/locale/messages.es.xlf
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="es" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="2df64767cd895a8fabe3e18b94b5b6b6f9e2e3f0" datatype="html">
+        <source>TODAY</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/calendar/calendar.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The label for the today button in the calendar header</note>
+        <note priority="1" from="meaning">kendo.calendar.today</note>
+      </trans-unit>
+      <trans-unit id="a55944f9de69e7cc86b91200fe96f980a947d704" datatype="html">
+        <source>Increase value</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/dateinput/dateinput.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The label for the **Increment** button in the DateInput</note>
+        <note priority="1" from="meaning">kendo.dateinput.increment</note>
+      </trans-unit>
+      <trans-unit id="0eded761107e6dad120997006a7f915bade9b15c" datatype="html">
+        <source>Decrease value</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/dateinput/dateinput.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the **Decrement** button in the DateInput</note>
+        <note priority="1" from="meaning">kendo.dateinput.decrement</note>
+      </trans-unit>
+      <trans-unit id="91a84f2d4871dbe7e90d84865d4a4d83c8ae041e" datatype="html">
+        <source>TODAY</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datepicker/datepicker.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The label for the today button in the calendar header</note>
+        <note priority="1" from="meaning">kendo.datepicker.today</note>
+      </trans-unit>
+      <trans-unit id="f6c28c2d80dbe993c4b33f4dc4010364f41cc2ae" datatype="html">
+        <source>Toggle calendar</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datepicker/datepicker.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the toggle button in the datepicker component</note>
+        <note priority="1" from="meaning">kendo.datepicker.toggle</note>
+      </trans-unit>
+      <trans-unit id="4c3bf42192220c7611c09ece1c5de14855139dd0" datatype="html">
+        <source>Set</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The Accept button text in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.accept</note>
+      </trans-unit>
+      <trans-unit id="93c2a9c3aa49f56e452c0aecbaabe3bb33fa4222" datatype="html">
+        <source>Set time</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Accept button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.acceptLabel</note>
+      </trans-unit>
+      <trans-unit id="132eefca16bd41d489b4647724b91e93793603aa" datatype="html">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">The Cancel button text in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.cancel</note>
+      </trans-unit>
+      <trans-unit id="2cf6f4ca4470810944b4016c9b6f87943d3390ab" datatype="html">
+        <source>Cancel changes</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Cancel button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.cancelLabel</note>
+      </trans-unit>
+      <trans-unit id="bbc99bb74ae75a503bd813aad0c7253d3553e923" datatype="html">
+        <source>Now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">The Now button text in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.now</note>
+      </trans-unit>
+      <trans-unit id="df1a696f318275aa934e27850920889d494c2740" datatype="html">
+        <source>Select now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Now button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.nowLabel</note>
+      </trans-unit>
+      <trans-unit id="f2c196786ed2d3ecb2369750c36aac9a4053fb30" datatype="html">
+        <source>Toggle time list</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">The label for the toggle button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.toggle</note>
+      </trans-unit>
+      <trans-unit id="5bb17f81ae8dbc109499ce3792afffa6b7cef855" datatype="html">
+        <source>Date</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">The Date tab text in the datetimepicker popup header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.dateTab</note>
+      </trans-unit>
+      <trans-unit id="2a400c9e364a4c6d83ac39b5513c962805db54b2" datatype="html">
+        <source>Date tab</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Date tab in the datetimepicker popup header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.dateTabLabel</note>
+      </trans-unit>
+      <trans-unit id="e9b2b760a6916040e7520a9a2926d65de175944d" datatype="html">
+        <source>Time</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">The Time tab text in the datetimepicker popup header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.timeTab</note>
+      </trans-unit>
+      <trans-unit id="13bf7e3a1036140119732c6d5952f7a20c22999e" datatype="html">
+        <source>Time tab</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Time tab in the datetimepicker popup header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.timeTabLabel</note>
+      </trans-unit>
+      <trans-unit id="60296a83f0d3e3d07aaba87c4f8e91b0aca3c22a" datatype="html">
+        <source>Toggle popup</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">The label for the toggle button in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.toggle</note>
+      </trans-unit>
+      <trans-unit id="4359b59db7ded88e106ada877e744c71b188f8f9" datatype="html">
+        <source>Set</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <note priority="1" from="description">The Accept button text in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.accept</note>
+      </trans-unit>
+      <trans-unit id="cbea4571cca81ad9767a6b29f0287d1f3f6372dc" datatype="html">
+        <source>Set</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Accept button in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.acceptLabel</note>
+      </trans-unit>
+      <trans-unit id="17ab795d6f7527dd962a309759ca58cb4edd7e52" datatype="html">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">The Cancel button text in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.cancel</note>
+      </trans-unit>
+      <trans-unit id="ba26795ab9f4c21d66b17549ba854a96fcdac1f9" datatype="html">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Cancel button in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.cancelLabel</note>
+      </trans-unit>
+      <trans-unit id="7172e7e9a1741f6b63439ec89e498c995cb23b0d" datatype="html">
+        <source>NOW</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">The Now button text in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.now</note>
+      </trans-unit>
+      <trans-unit id="52d90641b26b1ce4c011cadf0437ce36c1dac1d5" datatype="html">
+        <source>Select now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Now button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.nowLabel</note>
+      </trans-unit>
+      <trans-unit id="7ee30b9ae5918cc544fbd87a4135694397aeefaf" datatype="html">
+        <source>TODAY</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <note priority="1" from="description">The label for the today button in the calendar header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.today</note>
+      </trans-unit>
+      <trans-unit id="063d99483243b27bc8282abfb5f2c76877e1112e" datatype="html">
+        <source>TODAY</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/calendar/multiview-calendar.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The label for the today button in the calendar header</note>
+        <note priority="1" from="meaning">kendo.multiviewcalendar.today</note>
+      </trans-unit>
+      <trans-unit id="e783e2af4828224b846fa92148ea1cc52b21bb13" datatype="html">
+        <source>Navigate to previous view</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/calendar/multiview-calendar.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the previous button in the Multiview calendar</note>
+        <note priority="1" from="meaning">kendo.multiviewcalendar.prevButtonTitle</note>
+      </trans-unit>
+      <trans-unit id="3e3a529a242f39d22f841c3bd8045ec75b696b7a" datatype="html">
+        <source>Navigate to next view</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/calendar/multiview-calendar.component.d.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">The label for the next button in the Multiview calendar</note>
+        <note priority="1" from="meaning">kendo.multiviewcalendar.nextButtonTitle</note>
+      </trans-unit>
+      <trans-unit id="801811aa1609e3f173c86baa82cee037f75a215f" datatype="html">
+        <source>Set</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The Accept button text in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.accept</note>
+      </trans-unit>
+      <trans-unit id="b4b1e5ac55f0330f6c4e32b866ae4339ad969978" datatype="html">
+        <source>Set time</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Accept button in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.acceptLabel</note>
+      </trans-unit>
+      <trans-unit id="3004d7704ffa6202a3b3925fcea490e486203a3e" datatype="html">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">The Cancel button text in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.cancel</note>
+      </trans-unit>
+      <trans-unit id="08dfbdfffd662371a6ff4c0b6ed82b9faa48143b" datatype="html">
+        <source>Cancel changes</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Cancel button in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.cancelLabel</note>
+      </trans-unit>
+      <trans-unit id="98cba1ae36a7bbe15e1bac1837e07922ec109e7d" datatype="html">
+        <source>Now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">The Now button text in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.now</note>
+      </trans-unit>
+      <trans-unit id="08e6a8a51d970609e138950fdd89c5cf201869f3" datatype="html">
+        <source>Select now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Now button in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.nowLabel</note>
+      </trans-unit>
+      <trans-unit id="5a10e4d6d09c3955ba4f3c67d1f642e8f8172733" datatype="html">
+        <source>Hello, World!</source>
+        <target>¡Hola Mundo!</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <note priority="1" from="description">An introduction header for this sample</note>
+        <note priority="1" from="meaning">User welcome</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/projects/kendo-ui-i18n-ngcc/src/locale/messages.xlf
+++ b/projects/kendo-ui-i18n-ngcc/src/locale/messages.xlf
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en-US" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="2df64767cd895a8fabe3e18b94b5b6b6f9e2e3f0" datatype="html">
+        <source>TODAY</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/calendar/calendar.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The label for the today button in the calendar header</note>
+        <note priority="1" from="meaning">kendo.calendar.today</note>
+      </trans-unit>
+      <trans-unit id="a55944f9de69e7cc86b91200fe96f980a947d704" datatype="html">
+        <source>Increase value</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/dateinput/dateinput.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The label for the **Increment** button in the DateInput</note>
+        <note priority="1" from="meaning">kendo.dateinput.increment</note>
+      </trans-unit>
+      <trans-unit id="0eded761107e6dad120997006a7f915bade9b15c" datatype="html">
+        <source>Decrease value</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/dateinput/dateinput.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the **Decrement** button in the DateInput</note>
+        <note priority="1" from="meaning">kendo.dateinput.decrement</note>
+      </trans-unit>
+      <trans-unit id="91a84f2d4871dbe7e90d84865d4a4d83c8ae041e" datatype="html">
+        <source>TODAY</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datepicker/datepicker.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The label for the today button in the calendar header</note>
+        <note priority="1" from="meaning">kendo.datepicker.today</note>
+      </trans-unit>
+      <trans-unit id="f6c28c2d80dbe993c4b33f4dc4010364f41cc2ae" datatype="html">
+        <source>Toggle calendar</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datepicker/datepicker.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the toggle button in the datepicker component</note>
+        <note priority="1" from="meaning">kendo.datepicker.toggle</note>
+      </trans-unit>
+      <trans-unit id="4c3bf42192220c7611c09ece1c5de14855139dd0" datatype="html">
+        <source>Set</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The Accept button text in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.accept</note>
+      </trans-unit>
+      <trans-unit id="93c2a9c3aa49f56e452c0aecbaabe3bb33fa4222" datatype="html">
+        <source>Set time</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Accept button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.acceptLabel</note>
+      </trans-unit>
+      <trans-unit id="132eefca16bd41d489b4647724b91e93793603aa" datatype="html">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">The Cancel button text in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.cancel</note>
+      </trans-unit>
+      <trans-unit id="2cf6f4ca4470810944b4016c9b6f87943d3390ab" datatype="html">
+        <source>Cancel changes</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Cancel button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.cancelLabel</note>
+      </trans-unit>
+      <trans-unit id="bbc99bb74ae75a503bd813aad0c7253d3553e923" datatype="html">
+        <source>Now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">The Now button text in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.now</note>
+      </trans-unit>
+      <trans-unit id="df1a696f318275aa934e27850920889d494c2740" datatype="html">
+        <source>Select now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Now button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.nowLabel</note>
+      </trans-unit>
+      <trans-unit id="f2c196786ed2d3ecb2369750c36aac9a4053fb30" datatype="html">
+        <source>Toggle time list</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timepicker.component.d.ts</context>
+          <context context-type="linenumber">22</context>
+        </context-group>
+        <note priority="1" from="description">The label for the toggle button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.timepicker.toggle</note>
+      </trans-unit>
+      <trans-unit id="5bb17f81ae8dbc109499ce3792afffa6b7cef855" datatype="html">
+        <source>Date</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">6</context>
+        </context-group>
+        <note priority="1" from="description">The Date tab text in the datetimepicker popup header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.dateTab</note>
+      </trans-unit>
+      <trans-unit id="2a400c9e364a4c6d83ac39b5513c962805db54b2" datatype="html">
+        <source>Date tab</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">9</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Date tab in the datetimepicker popup header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.dateTabLabel</note>
+      </trans-unit>
+      <trans-unit id="e9b2b760a6916040e7520a9a2926d65de175944d" datatype="html">
+        <source>Time</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+        <note priority="1" from="description">The Time tab text in the datetimepicker popup header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.timeTab</note>
+      </trans-unit>
+      <trans-unit id="13bf7e3a1036140119732c6d5952f7a20c22999e" datatype="html">
+        <source>Time tab</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Time tab in the datetimepicker popup header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.timeTabLabel</note>
+      </trans-unit>
+      <trans-unit id="60296a83f0d3e3d07aaba87c4f8e91b0aca3c22a" datatype="html">
+        <source>Toggle popup</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <note priority="1" from="description">The label for the toggle button in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.toggle</note>
+      </trans-unit>
+      <trans-unit id="4359b59db7ded88e106ada877e744c71b188f8f9" datatype="html">
+        <source>Set</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <note priority="1" from="description">The Accept button text in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.accept</note>
+      </trans-unit>
+      <trans-unit id="cbea4571cca81ad9767a6b29f0287d1f3f6372dc" datatype="html">
+        <source>Set</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Accept button in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.acceptLabel</note>
+      </trans-unit>
+      <trans-unit id="17ab795d6f7527dd962a309759ca58cb4edd7e52" datatype="html">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">27</context>
+        </context-group>
+        <note priority="1" from="description">The Cancel button text in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.cancel</note>
+      </trans-unit>
+      <trans-unit id="ba26795ab9f4c21d66b17549ba854a96fcdac1f9" datatype="html">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Cancel button in the datetimepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.cancelLabel</note>
+      </trans-unit>
+      <trans-unit id="7172e7e9a1741f6b63439ec89e498c995cb23b0d" datatype="html">
+        <source>NOW</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+        <note priority="1" from="description">The Now button text in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.now</note>
+      </trans-unit>
+      <trans-unit id="52d90641b26b1ce4c011cadf0437ce36c1dac1d5" datatype="html">
+        <source>Select now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Now button in the timepicker component</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.nowLabel</note>
+      </trans-unit>
+      <trans-unit id="7ee30b9ae5918cc544fbd87a4135694397aeefaf" datatype="html">
+        <source>TODAY</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/datetimepicker/datetimepicker.component.d.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+        <note priority="1" from="description">The label for the today button in the calendar header</note>
+        <note priority="1" from="meaning">kendo.datetimepicker.today</note>
+      </trans-unit>
+      <trans-unit id="063d99483243b27bc8282abfb5f2c76877e1112e" datatype="html">
+        <source>TODAY</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/calendar/multiview-calendar.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The label for the today button in the calendar header</note>
+        <note priority="1" from="meaning">kendo.multiviewcalendar.today</note>
+      </trans-unit>
+      <trans-unit id="e783e2af4828224b846fa92148ea1cc52b21bb13" datatype="html">
+        <source>Navigate to previous view</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/calendar/multiview-calendar.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the previous button in the Multiview calendar</note>
+        <note priority="1" from="meaning">kendo.multiviewcalendar.prevButtonTitle</note>
+      </trans-unit>
+      <trans-unit id="3e3a529a242f39d22f841c3bd8045ec75b696b7a" datatype="html">
+        <source>Navigate to next view</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/calendar/multiview-calendar.component.d.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">The label for the next button in the Multiview calendar</note>
+        <note priority="1" from="meaning">kendo.multiviewcalendar.nextButtonTitle</note>
+      </trans-unit>
+      <trans-unit id="801811aa1609e3f173c86baa82cee037f75a215f" datatype="html">
+        <source>Set</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+        <note priority="1" from="description">The Accept button text in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.accept</note>
+      </trans-unit>
+      <trans-unit id="b4b1e5ac55f0330f6c4e32b866ae4339ad969978" datatype="html">
+        <source>Set time</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Accept button in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.acceptLabel</note>
+      </trans-unit>
+      <trans-unit id="3004d7704ffa6202a3b3925fcea490e486203a3e" datatype="html">
+        <source>Cancel</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+        <note priority="1" from="description">The Cancel button text in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.cancel</note>
+      </trans-unit>
+      <trans-unit id="08dfbdfffd662371a6ff4c0b6ed82b9faa48143b" datatype="html">
+        <source>Cancel changes</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Cancel button in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.cancelLabel</note>
+      </trans-unit>
+      <trans-unit id="98cba1ae36a7bbe15e1bac1837e07922ec109e7d" datatype="html">
+        <source>Now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+        <note priority="1" from="description">The Now button text in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.now</note>
+      </trans-unit>
+      <trans-unit id="08e6a8a51d970609e138950fdd89c5cf201869f3" datatype="html">
+        <source>Select now</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">../../node_modules/@progress/kendo-angular-dateinputs/dist/es2015/timepicker/timeselector.component.d.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <note priority="1" from="description">The label for the Now button in the timeselector component</note>
+        <note priority="1" from="meaning">kendo.timeselector.nowLabel</note>
+      </trans-unit>
+      <trans-unit id="5a10e4d6d09c3955ba4f3c67d1f642e8f8172733" datatype="html">
+        <source>Hello, World!</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+        <note priority="1" from="description">An introduction header for this sample</note>
+        <note priority="1" from="meaning">User welcome</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,16 +49,14 @@
     rxjs "6.4.0"
 
 "@angular-devkit/architect@github:angular/angular-devkit-architect-builds#48882a0f3":
-  version "0.900.0-next.19+246.48882a0"
-  uid a8da23bb3d95ae85370dfe447bf207f5228aa37f
+  version "0.900.0-next.19"
   resolved "https://codeload.github.com/angular/angular-devkit-architect-builds/tar.gz/a8da23bb3d95ae85370dfe447bf207f5228aa37f"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#48882a0f3"
     rxjs "6.5.3"
 
 "@angular-devkit/build-angular@github:angular/angular-devkit-build-angular-builds#5343853ac79349dbb2470f858ce5239b4fb936bb":
-  version "0.900.0-next.19+246.48882a0"
-  uid "5343853ac79349dbb2470f858ce5239b4fb936bb"
+  version "0.900.0-next.19"
   resolved "https://codeload.github.com/angular/angular-devkit-build-angular-builds/tar.gz/5343853ac79349dbb2470f858ce5239b4fb936bb"
   dependencies:
     "@angular-devkit/architect" "github:angular/angular-devkit-architect-builds#48882a0f3"
@@ -124,8 +122,7 @@
     worker-plugin "3.2.0"
 
 "@angular-devkit/build-optimizer@github:angular/angular-devkit-build-optimizer-builds#48882a0f3":
-  version "0.900.0-next.19+246.48882a0"
-  uid bdeb68a08d457f0cf4840b0fb2ed628851e44741
+  version "0.900.0-next.19"
   resolved "https://codeload.github.com/angular/angular-devkit-build-optimizer-builds/tar.gz/bdeb68a08d457f0cf4840b0fb2ed628851e44741"
   dependencies:
     loader-utils "1.2.3"
@@ -135,8 +132,7 @@
     webpack-sources "1.4.3"
 
 "@angular-devkit/build-webpack@github:angular/angular-devkit-build-webpack-builds#48882a0f3":
-  version "0.900.0-next.19+246.48882a0"
-  uid d01d8bd30e3cb09413ae65a0755e55527f3dd40a
+  version "0.900.0-next.19"
   resolved "https://codeload.github.com/angular/angular-devkit-build-webpack-builds/tar.gz/d01d8bd30e3cb09413ae65a0755e55527f3dd40a"
   dependencies:
     "@angular-devkit/architect" "github:angular/angular-devkit-architect-builds#48882a0f3"
@@ -177,8 +173,7 @@
     source-map "0.7.3"
 
 "@angular-devkit/core@github:angular/angular-devkit-core-builds#48882a0f3":
-  version "9.0.0-next.19+246.48882a0"
-  uid aab83e148b48c63e97d0421229929b776288b5e9
+  version "9.0.0-next.19"
   resolved "https://codeload.github.com/angular/angular-devkit-core-builds/tar.gz/aab83e148b48c63e97d0421229929b776288b5e9"
   dependencies:
     ajv "6.10.2"
@@ -212,8 +207,7 @@
     rxjs "6.3.3"
 
 "@angular-devkit/schematics@github:angular/angular-devkit-schematics-builds#48882a0f3":
-  version "9.0.0-next.19+246.48882a0"
-  uid bb7846c1091158f66513668df5f7382506f3c65f
+  version "9.0.0-next.19"
   resolved "https://codeload.github.com/angular/angular-devkit-schematics-builds/tar.gz/bb7846c1091158f66513668df5f7382506f3c65f"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#48882a0f3"
@@ -228,8 +222,7 @@
     tslib "^1.9.0"
 
 "@angular/animations@github:angular/animations-builds#ec73583d6346a35b1fa6dc2d2ac83f12cf161387":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid ec73583d6346a35b1fa6dc2d2ac83f12cf161387
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/animations-builds/tar.gz/ec73583d6346a35b1fa6dc2d2ac83f12cf161387"
 
 "@angular/cdk@8.2.3", "@angular/cdk@^8.0.0":
@@ -268,8 +261,7 @@
     uuid "^3.3.2"
 
 "@angular/cli@github:angular/cli-builds#bf842d26abe8c090746a17e4e8de6300e2d66858":
-  version "9.0.0-next.19+246.48882a0"
-  uid bf842d26abe8c090746a17e4e8de6300e2d66858
+  version "9.0.0-next.19"
   resolved "https://codeload.github.com/angular/cli-builds/tar.gz/bf842d26abe8c090746a17e4e8de6300e2d66858"
   dependencies:
     "@angular-devkit/architect" "github:angular/angular-devkit-architect-builds#48882a0f3"
@@ -294,13 +286,11 @@
     uuid "^3.3.2"
 
 "@angular/common@github:angular/common-builds#3ff8857dbc2fabbe3387599be238900a78b4c039":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid "3ff8857dbc2fabbe3387599be238900a78b4c039"
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/common-builds/tar.gz/3ff8857dbc2fabbe3387599be238900a78b4c039"
 
 "@angular/compiler-cli@github:angular/compiler-cli-builds#829c4ccf6f11f6f60a4c2a48ff4cb0c52dcef6ba":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid "829c4ccf6f11f6f60a4c2a48ff4cb0c52dcef6ba"
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/compiler-cli-builds/tar.gz/829c4ccf6f11f6f60a4c2a48ff4cb0c52dcef6ba"
   dependencies:
     canonical-path "1.0.0"
@@ -315,18 +305,15 @@
     yargs "13.1.0"
 
 "@angular/compiler@github:angular/compiler-builds#f4d7a4ec3f5c3f800b0bd60997750bae0f39e73f":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid f4d7a4ec3f5c3f800b0bd60997750bae0f39e73f
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/compiler-builds/tar.gz/f4d7a4ec3f5c3f800b0bd60997750bae0f39e73f"
 
 "@angular/core@github:angular/core-builds#89b79ad3c0c2a93b3fc761bd2130418aef05ca15":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid "89b79ad3c0c2a93b3fc761bd2130418aef05ca15"
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/core-builds/tar.gz/89b79ad3c0c2a93b3fc761bd2130418aef05ca15"
 
 "@angular/elements@github:angular/elements-builds#254abba570b27c985e32a127c554dbba6727b374":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid "254abba570b27c985e32a127c554dbba6727b374"
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/elements-builds/tar.gz/254abba570b27c985e32a127c554dbba6727b374"
 
 "@angular/fire@5.2.3":
@@ -342,8 +329,7 @@
     tslib "^1.7.1"
 
 "@angular/forms@github:angular/forms-builds#ebdaecb27cb140c665344e6a6967d70715ebf07a":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid ebdaecb27cb140c665344e6a6967d70715ebf07a
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/forms-builds/tar.gz/ebdaecb27cb140c665344e6a6967d70715ebf07a"
 
 "@angular/http@^7.2.15":
@@ -354,8 +340,7 @@
     tslib "^1.9.0"
 
 "@angular/language-service@github:angular/language-service-builds#2f28d01fcfd3bbfa6371dd14ab57483c8649e35d":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid "2f28d01fcfd3bbfa6371dd14ab57483c8649e35d"
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/language-service-builds/tar.gz/2f28d01fcfd3bbfa6371dd14ab57483c8649e35d"
 
 "@angular/localize@next":
@@ -389,36 +374,30 @@
     tslib "^1.7.1"
 
 "@angular/platform-browser-dynamic@github:angular/platform-browser-dynamic-builds#aca1cde34632340cc06da5886bc07cdec9a57292":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid aca1cde34632340cc06da5886bc07cdec9a57292
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/platform-browser-dynamic-builds/tar.gz/aca1cde34632340cc06da5886bc07cdec9a57292"
 
 "@angular/platform-browser@github:angular/platform-browser-builds#ea15e4bfdbd5ea91f50ff3040c860c5c57f94ce9":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid ea15e4bfdbd5ea91f50ff3040c860c5c57f94ce9
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/platform-browser-builds/tar.gz/ea15e4bfdbd5ea91f50ff3040c860c5c57f94ce9"
 
 "@angular/platform-server@github:angular/platform-server-builds#aa66576174688f8c70a3f12a3ce8f8110397245f":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid aa66576174688f8c70a3f12a3ce8f8110397245f
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/platform-server-builds/tar.gz/aa66576174688f8c70a3f12a3ce8f8110397245f"
   dependencies:
     domino "^2.1.2"
     xhr2 "^0.1.4"
 
 "@angular/router@github:angular/router-builds#bb3389243b472438d12c236d34e58b4ffb9ba78d":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid bb3389243b472438d12c236d34e58b4ffb9ba78d
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/router-builds/tar.gz/bb3389243b472438d12c236d34e58b4ffb9ba78d"
 
 "@angular/service-worker@github:angular/service-worker-builds#2152a54a625bd65efcb5d38ac67d7bd22aa02883":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid "2152a54a625bd65efcb5d38ac67d7bd22aa02883"
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/service-worker-builds/tar.gz/2152a54a625bd65efcb5d38ac67d7bd22aa02883"
 
 "@angular/upgrade@github:angular/upgrade-builds#e298d2185622433d6f22d351bddd955b004fb1c6":
-  version "9.0.0-rc.1+519.sha-260a061"
-  uid e298d2185622433d6f22d351bddd955b004fb1c6
+  version "9.0.0-rc.1"
   resolved "https://codeload.github.com/angular/upgrade-builds/tar.gz/e298d2185622433d6f22d351bddd955b004fb1c6"
 
 "@angularclass/hmr@^2.1.3":
@@ -2314,8 +2293,7 @@
   integrity sha512-JPlc23Aw3rlEKt6LCkg3a0zlo0tEgkohH3CDHVbUIYSgg3DWOnmNfwztbz4pa2u2wua5PfFCovC7HKTNmapx/w==
 
 "@ngtools/webpack@github:angular/ngtools-webpack-builds#48882a0f3":
-  version "9.0.0-next.19+246.48882a0"
-  uid "90c4a79bab2d9490f4d1b52030cdaab0d390bb50"
+  version "9.0.0-next.19"
   resolved "https://codeload.github.com/angular/ngtools-webpack-builds/tar.gz/90c4a79bab2d9490f4d1b52030cdaab0d390bb50"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#48882a0f3"
@@ -2933,8 +2911,7 @@
     "@angular-devkit/schematics" "8.3.20"
 
 "@schematics/angular@github:angular/schematics-angular-builds#48882a0f3":
-  version "9.0.0-next.19+246.48882a0"
-  uid b559fd94a0bea185396c2ff9e4281d89b71bec30
+  version "9.0.0-next.19"
   resolved "https://codeload.github.com/angular/schematics-angular-builds/tar.gz/b559fd94a0bea185396c2ff9e4281d89b71bec30"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#48882a0f3"
@@ -2955,8 +2932,7 @@
     semver-intersect "1.4.0"
 
 "@schematics/update@github:angular/schematics-update-builds#48882a0f3":
-  version "0.900.0-next.19+246.48882a0"
-  uid "8836c79dc90de2abb5cef22697dc2e1d1a7be1b7"
+  version "0.900.0-next.19"
   resolved "https://codeload.github.com/angular/schematics-update-builds/tar.gz/8836c79dc90de2abb5cef22697dc2e1d1a7be1b7"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#48882a0f3"
@@ -3587,13 +3563,6 @@ angular-2-dropdown-multiselect@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/angular-2-dropdown-multiselect/-/angular-2-dropdown-multiselect-1.9.0.tgz#44c9807f4bc01278d17b9c1824308f44108748de"
   integrity sha512-3zFlmC044N9ztCyxURHsS0lCOn2bmRKO8ZFllvD2noluHONk7iPMq3pJ8QmDTtOUeq52ydmyhkgw8DvWqZt62A==
-  dependencies:
-    tslib "^1.9.0"
-
-angular-bootstrap-datetimepicker@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/angular-bootstrap-datetimepicker/-/angular-bootstrap-datetimepicker-4.0.2.tgz#28563fd17c461a26b59d4e21b31f5146a4e3d53c"
-  integrity sha512-FEhPbpVszPKw5CUSyk/QKWsTlsGPC6KS2MQawVr4LfQN/foOaGM3hvw6mMl0ASrAZtikcsFa5h2cA5GLJMPZBg==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
Test case for the Grid filtering with the latest Angular builds.
1. Run `ng serve kendo-ui-grid-ngcc`
1. Open http://localhost:4200/
1. Enter a value in any of the filter fields

Note: Removed the `angular-bootstrap-datetimepicker` package as it requires Node v12.

**DO NOT MERGE**