### PR TITLE
fix: add polyfill to kendo-ui projects

### DIFF
--- a/projects/kendo-ui-dialog-ngcc/src/polyfills.ts
+++ b/projects/kendo-ui-dialog-ngcc/src/polyfills.ts
@@ -61,3 +61,4 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
+import '@angular/localize/init';

--- a/projects/kendo-ui-notification-ngcc/e2e/src/app.po.ts
+++ b/projects/kendo-ui-notification-ngcc/e2e/src/app.po.ts
@@ -6,7 +6,7 @@ export class AppPage {
   }
 
   getButtonAt(index: number) {
-    return element(by.css('app-root button'));
+    return element.all(by.css('app-root button')).get(index);
   }
 
   getNotificationText() {

--- a/projects/kendo-ui-notification-ngcc/src/polyfills.ts
+++ b/projects/kendo-ui-notification-ngcc/src/polyfills.ts
@@ -61,3 +61,4 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
+import '@angular/localize/init';


### PR DESCRIPTION
The Dialog and Editor components added localized messages in the latest versions. See build failures in #810.