### PR TITLE
ci: configure renovate to update Angular framework, Material and CLI separately

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,9 +21,29 @@
     },
     {
       "packagePatterns": [
-        "^@angular.*"
+        "^@angular/"
       ],
-      "groupName": "angular"
+      "excludePackagePatterns": [
+        "^@angular-devkit/",
+        "^@angular/cli$",
+        "^@angular/cdk$",
+        "^@angular/material$"
+      ],
+      "groupName": "angular-framework"
+    },
+    {
+      "packagePatterns": [
+        "^@angular-devkit/",
+        "^@angular/cli$"
+      ],
+      "groupName": "angular-cli"
+    },
+    {
+      "packagePatterns": [
+        "^@angular/cdk$",
+        "^@angular/material$"
+      ],
+      "groupName": "angular-components"
     },
     {
       "packagePatterns": [


### PR DESCRIPTION
Previously, all packages starting with `@angular` would be updated in a single PR. This made it difficult to investigate regressions that could have been caused by either the Angular framework or Angular material or the Angular CLI (e.g. in #839).

This commit configures Renovate to update framework, Material and CLI separately.