### PR TITLE
ci: fix patterns for `angular-components` Renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
         "^@angular-devkit/",
         "^@angular/cli$",
         "^@angular/cdk$",
-        "^@angular/material$"
+        "^@angular/material"
       ],
       "groupName": "angular-framework"
     },
@@ -41,7 +41,7 @@
     {
       "packagePatterns": [
         "^@angular/cdk$",
-        "^@angular/material$"
+        "^@angular/material"
       ],
       "groupName": "angular-components"
     },


### PR DESCRIPTION
Ensure other material packages, such as `@angular/material-experimental` and `@angular/material-moment-adapter` are part of the `angular-components` update group in Renovate config.