### PR TITLE
ci: retry failed jobs to reduce flakes

### DIFF
--- a/infra/build-project.js
+++ b/infra/build-project.js
@@ -26,7 +26,7 @@ function runCmd(cmd, retryAttempts = 1) {
   } catch (err) {
     if (retryAttempts > 0) {
       console.log(`Retrying command '${cmd}'...`);
-      return runCmd(cmd, --retryAttempts);
+      return runCmd(cmd, retryAttempts - 1);
     } else {
       throw err;
     }

--- a/infra/build-project.js
+++ b/infra/build-project.js
@@ -1,12 +1,12 @@
-const { parentPort, workerData, isMainThread } = require("worker_threads");
 const { execSync } = require('child_process');
+const { isMainThread, parentPort, workerData } = require('worker_threads');
 
 if (!isMainThread) {
   if (typeof workerData !== 'string') {
     throw new Error('workerData must be a string');
   }
   try {
-    const res = execSync(workerData, { stdio: 'pipe' });
+    const res = runCmd(workerData);
     parentPort.postMessage({
       success: true,
       out: res.toString()
@@ -16,5 +16,19 @@ if (!isMainThread) {
       success: false,
       out: `stderr: ${e.stderr.toString()}\nstdout: ${e.stdout.toString()}\n`
     });
+  }
+}
+
+// Helpers
+function runCmd(cmd, retryAttempts = 1) {
+  try {
+    return execSync(cmd, { stdio: 'pipe' });
+  } catch (err) {
+    if (retryAttempts > 0) {
+      console.log(`Retrying command '${cmd}'...`);
+      return runCmd(cmd, --retryAttempts);
+    } else {
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
Sometimes, tests for a package fail due to random flakes. To reduce the failures due to these flakes, this commit attempts to run failed jobs commands a second time.

Example flakes:
- https://circleci.com/gh/angular/ngcc-validation/3979
- https://circleci.com/gh/angular/ngcc-validation/3980