### PR TITLE
Remove `covalentcore-ngcc` from failing projects

### DIFF
--- a/infra/failing-projects.json
+++ b/infra/failing-projects.json
@@ -1,7 +1,6 @@
 [
   "alfrescoadf-core-ngcc",
   "carbonicons-angular-ngcc",
-  "covalentcore-ngcc",
   "harborui-ngcc",
   "nativescript-angular-ngcc",
   "ng6-breadcrumbs-ngcc",


### PR DESCRIPTION
@covalent/core v3 no longer fails to be processed by ngcc.
Fixed by #1045.