### PR TITLE
build: upgrade TypeScript to 3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "redux-devtools-extension": "2.13.8",
     "ts-node": "8.10.1",
     "tslint": "~6.1.0",
-    "typescript": "3.6.4",
+    "typescript": "^3.8.3",
     "yargs": "^15.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,16 +41,14 @@
     rxjs "6.5.4"
 
 "@angular-devkit/architect@github:angular/angular-devkit-architect-builds#a7cf22cab":
-  version "0.1000.0-next.3+49.a7cf22c"
-  uid "4465cbf0cb6133018ab480d82abcad42d8c839ae"
+  version "0.1000.0-next.3"
   resolved "https://codeload.github.com/angular/angular-devkit-architect-builds/tar.gz/4465cbf0cb6133018ab480d82abcad42d8c839ae"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#a7cf22cab"
     rxjs "6.5.5"
 
 "@angular-devkit/build-angular@github:angular/angular-devkit-build-angular-builds#789a1da00b3725426121bb1a7af5f68661da05fd":
-  version "0.1000.0-next.3+49.a7cf22c"
-  uid "789a1da00b3725426121bb1a7af5f68661da05fd"
+  version "0.1000.0-next.3"
   resolved "https://codeload.github.com/angular/angular-devkit-build-angular-builds/tar.gz/789a1da00b3725426121bb1a7af5f68661da05fd"
   dependencies:
     "@angular-devkit/architect" "github:angular/angular-devkit-architect-builds#a7cf22cab"
@@ -118,8 +116,7 @@
     worker-plugin "4.0.3"
 
 "@angular-devkit/build-optimizer@github:angular/angular-devkit-build-optimizer-builds#a7cf22cab":
-  version "0.1000.0-next.3+49.a7cf22c"
-  uid "1bf1f60845e77062a2822881a96d73fb8e1dc961"
+  version "0.1000.0-next.3"
   resolved "https://codeload.github.com/angular/angular-devkit-build-optimizer-builds/tar.gz/1bf1f60845e77062a2822881a96d73fb8e1dc961"
   dependencies:
     loader-utils "2.0.0"
@@ -129,8 +126,7 @@
     webpack-sources "1.4.3"
 
 "@angular-devkit/build-webpack@github:angular/angular-devkit-build-webpack-builds#a7cf22cab":
-  version "0.1000.0-next.3+49.a7cf22c"
-  uid df3f24917ed0dc9f5a23fa8f538384f7dce2d9fe
+  version "0.1000.0-next.3"
   resolved "https://codeload.github.com/angular/angular-devkit-build-webpack-builds/tar.gz/df3f24917ed0dc9f5a23fa8f538384f7dce2d9fe"
   dependencies:
     "@angular-devkit/architect" "github:angular/angular-devkit-architect-builds#a7cf22cab"
@@ -171,8 +167,7 @@
     source-map "0.7.3"
 
 "@angular-devkit/core@github:angular/angular-devkit-core-builds#a7cf22cab":
-  version "10.0.0-next.3+49.a7cf22c"
-  uid ad45c92bd71008fa29c66e928baad107b6514594
+  version "10.0.0-next.3"
   resolved "https://codeload.github.com/angular/angular-devkit-core-builds/tar.gz/ad45c92bd71008fa29c66e928baad107b6514594"
   dependencies:
     ajv "6.12.2"
@@ -207,8 +202,7 @@
     rxjs "6.3.3"
 
 "@angular-devkit/schematics@github:angular/angular-devkit-schematics-builds#a7cf22cab":
-  version "10.0.0-next.3+49.a7cf22c"
-  uid "93b2f5c38a06d49ed06c302a4a1c427914666ae8"
+  version "10.0.0-next.3"
   resolved "https://codeload.github.com/angular/angular-devkit-schematics-builds/tar.gz/93b2f5c38a06d49ed06c302a4a1c427914666ae8"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#a7cf22cab"
@@ -260,8 +254,7 @@
     uuid "7.0.2"
 
 "@angular/cli@github:angular/cli-builds#dbfb7334e342d917a427f3f6cfdb6aeaada6e1a3":
-  version "10.0.0-next.3+49.a7cf22c"
-  uid dbfb7334e342d917a427f3f6cfdb6aeaada6e1a3
+  version "10.0.0-next.3"
   resolved "https://codeload.github.com/angular/cli-builds/tar.gz/dbfb7334e342d917a427f3f6cfdb6aeaada6e1a3"
   dependencies:
     "@angular-devkit/architect" "github:angular/angular-devkit-architect-builds#a7cf22cab"
@@ -3164,8 +3157,7 @@
   integrity sha512-QnmfXJ4G2jp+vFaqT5Qfp6h0J9OHxfDKI2RbnMU93Tq1Xd/WVPzXnOQGjILBjwwWI6RFkSdIpUoQONr7VOW63g==
 
 "@ngtools/webpack@github:angular/ngtools-webpack-builds#a7cf22cab":
-  version "10.0.0-next.3+49.a7cf22c"
-  uid "1f6ab3aa5394b53767c9d7d840104ad1ca985838"
+  version "10.0.0-next.3"
   resolved "https://codeload.github.com/angular/ngtools-webpack-builds/tar.gz/1f6ab3aa5394b53767c9d7d840104ad1ca985838"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#a7cf22cab"
@@ -3841,8 +3833,7 @@
     "@angular-devkit/schematics" "8.3.20"
 
 "@schematics/angular@github:angular/schematics-angular-builds#a7cf22cab":
-  version "10.0.0-next.3+49.a7cf22c"
-  uid c770baebdcdf28ee86c17aec2c175387eb681bfc
+  version "10.0.0-next.3"
   resolved "https://codeload.github.com/angular/schematics-angular-builds/tar.gz/c770baebdcdf28ee86c17aec2c175387eb681bfc"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#a7cf22cab"
@@ -3864,8 +3855,7 @@
     semver-intersect "1.4.0"
 
 "@schematics/update@github:angular/schematics-update-builds#a7cf22cab":
-  version "0.1000.0-next.3+49.a7cf22c"
-  uid "5f64d8882b601083de44e6c24b88eab80b03d818"
+  version "0.1000.0-next.3"
   resolved "https://codeload.github.com/angular/schematics-update-builds/tar.gz/5f64d8882b601083de44e6c24b88eab80b03d818"
   dependencies:
     "@angular-devkit/core" "github:angular/angular-devkit-core-builds#a7cf22cab"
@@ -14795,11 +14785,6 @@ typescript@3.5.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
-
 typescript@3.6.5:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
@@ -14809,6 +14794,11 @@ typescript@^3.3.3333:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+
+typescript@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@0.7.21:
   version "0.7.21"


### PR DESCRIPTION
Support for TypeScript version <3.8 was dropped from Angular in angular/angular#36329. In order to allow updates to the latest Angular framework, this commit updates TypeScript to the latest 3.8.x version.
