### PR TITLE
fix(bugsnagplugin-angular-ngcc): use a 32 chars hex string as API key

### DIFF
--- a/projects/bugsnagplugin-angular-ngcc/src/app/app.module.ts
+++ b/projects/bugsnagplugin-angular-ngcc/src/app/app.module.ts
@@ -7,7 +7,8 @@ import Bugsnag from '@bugsnag/js';
 import { AppComponent } from './app.component';
 
 export function errorHandlerFactory() {
-  Bugsnag.start('API_KEY');
+  // The API key must be a string of 32 hexadecimal characters.
+  Bugsnag.start('0123456789ABCDEF0123456789ABCDEF');
   return new BugsnagErrorHandler();
 }
 


### PR DESCRIPTION
Bugsnag complains that the API key should be a string of 32 hexadecimal characters. Using a dummy 32 char long string to keep Bugsnag from complaining.
