### PR TITLE
build(deps): update @angular/flex-layout to v9.0.0-beta.30

### DIFF
--- a/ngcc.config.standalone.js
+++ b/ngcc.config.standalone.js
@@ -15,23 +15,6 @@ module.exports = {
       },
     },
 
-    // The UMD bundle of the primary entry-point of `@angular/flex-layout` includes all secondary
-    // entry-points (`core`, `extended`, `flex`, and `grid`), resulting in trying to process the
-    // typings twice (once when processing each secondary entry-point and once when processing the
-    // primary one).
-    //
-    // Skip processing the UMD format for the primary entry-point to avoid the error. The code will
-    // be processed anyway as part of the secondary entry-points.
-    '@angular/flex-layout': {
-      entryPoints: {
-        '.': {
-          override: {
-            main: undefined,
-          },
-        },
-      },
-    },
-
     // `@carbon/icons-angular` v11 (currently v11.0.0 and v11.0.1) has incorrect values for
     // `package.json > main`, pointing to a non-existent file
     // (`bundles/carbon-components-angular.js`) instead of the correct one:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@angular/core": "github:angular/core-builds#338dfbfb64a211f21c590cfd747ae51528132796",
     "@angular/elements": "github:angular/elements-builds#710cfb5b0dba72e88564138dd7c98d05b1c95ae4",
     "@angular/fire": "^6.0.0",
-    "@angular/flex-layout": "^9.0.0-beta.28",
+    "@angular/flex-layout": "^9.0.0-beta.30",
     "@angular/forms": "github:angular/forms-builds#d35053d00f8325920098acc3a820462719dd9a10",
     "@angular/http": "^7.2.15",
     "@angular/localize": "next",

--- a/renovate.json
+++ b/renovate.json
@@ -24,10 +24,10 @@
         "^@angular/"
       ],
       "excludePackagePatterns": [
-        "^@angular-devkit/",
         "^@angular/cli$",
         "^@angular/cdk$",
         "^@angular/fire$",
+        "^@angular/flex-layout$",
         "^@angular/material"
       ],
       "groupName": "angular-framework"
@@ -51,6 +51,12 @@
         "^@angular/fire$"
       ],
       "groupName": "angular-fire"
+    },
+    {
+      "packagePatterns": [
+        "^@angular/flex-layout$"
+      ],
+      "groupName": "angular-flex-layout"
     },
     {
       "packagePatterns": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,10 +329,10 @@
   resolved "https://registry.yarnpkg.com/@angular/fire/-/fire-6.0.0.tgz#c1dbae9e78ed74af951fb7222108c444300a4d15"
   integrity sha512-zWhaJaZPtfJKiNSb1I3WqqvopW0fN3S61w4PjPdsm5WME+9M9alP0zpRVclpbCU26LpBSLhrRrSLyn3ROlAOIw==
 
-"@angular/flex-layout@^9.0.0-beta.28":
-  version "9.0.0-beta.28"
-  resolved "https://registry.yarnpkg.com/@angular/flex-layout/-/flex-layout-9.0.0-beta.28.tgz#d040493781739ec9f1dfc3171aaaa35d800ad17d"
-  integrity sha512-VWyZ8NVtzS6pVkmTViVwzc8GWdUxql3FGtiVvdnqflr2/hnBaTxBjVJWBTZxQVJyzAwbi9WezarnfETMExsEkA==
+"@angular/flex-layout@^9.0.0-beta.30":
+  version "9.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/@angular/flex-layout/-/flex-layout-9.0.0-beta.30.tgz#ca18411a8842dcfe3d175931a6ff765e8c76f950"
+  integrity sha512-aPiw9sfuXpV99oFtbIbTJYC+GtubdggP66qO0JH5MCX+J8btCGAOJMf9RPJWx2yyh/VoSBOt2nWSYqcY5OEv+g==
 
 "@angular/forms@github:angular/forms-builds#d35053d00f8325920098acc3a820462719dd9a10":
   version "10.0.0-next.4"


### PR DESCRIPTION
The issue that caused ngcc processing to fail on UMD bundles has been fixed in this version of `@angular/flex-layout`, so we can remove the ngcc config for ignoring the UMD bundles.
