### PR TITLE
build: remove `alfrescoadf-core-ngcc` from failing projects

### DIFF
--- a/infra/failing-projects.json
+++ b/infra/failing-projects.json
@@ -1,5 +1,4 @@
 [
-  "alfrescoadf-core-ngcc",
   "devextreme-angular-ngcc",
   "nativescript-angular-ngcc",
   "ng6-breadcrumbs-ngcc"


### PR DESCRIPTION
It seems that the latest version of `@alfresco/*` packages can be successfully compiled by ngcc.
This PR removes `alfrescoadf-core-ngcc` from the list of failing projects.