### PR TITLE
ci: upgrade Node.js to v14.15.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,18 @@
 #
 version: 2.1
 
-# Note that the browser docker image comes with Chrome and Firefox preinstalled.
 # **NOTE 1**: Pin to exact images using an ID (SHA). See https://circleci.com/docs/2.0/circleci-images/#using-a-docker-image-id-to-pin-an-image-to-a-fixed-version.
 #             (Using the tag in not necessary when pinning by ID, but include it anyway for documentation purposes.)
 # **NOTE 2**: If you change the version of the docker images, also change the `cache_key` suffix.
-var_1: &docker_image circleci/node:12.11-browsers@sha256:a799729b2e3997086313757470cc4cb70067affab9818eddeb5c9cc80150ea3c
-var_2: &cache_key v2-ngcc-validation-{{ checksum "yarn.lock" }}-node-12.9
-var_3: &working_directory ~/repo
+# **NOTE 3**: The `*-browsers` docker image comes with Chrome and Firefox _dependencies_ preinstalled, but NOT the browsers themselves.
+#             See https://circleci.com/developer/images/image/cimg/node.
+# **NOTE 4**: Specify a ChromeDriver version that is compatible with the version of Chrome used.
+#             See https://chromedriver.chromium.org/downloads.
+var_1: &docker_image cimg/node:14.15.4-browsers@sha256:567deabc21e69837e4f1e5cfddeebb6c1b27cc606d40081753385161462f4282
+var_2: &cache_key v2-ngcc-validation-{{ checksum "yarn.lock" }}-node-14.15.4
+var_3: &chrome_version 88.0.4324.150
+var_4: &chromedriver_version 88.0.4324.96
+var_5: &working_directory ~/repo
 
 # Executor Definitions
 # https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors
@@ -20,9 +25,18 @@ executors:
       - image: *docker_image
     working_directory: *working_directory
 
+orbs:
+  browser-tools: circleci/browser-tools@1.1.1
+
 # Command Definitions
 # https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
 commands:
+  install_chrome:
+    description: Install the Chrome browser
+    steps:
+      - browser-tools/install-chrome:
+          chrome-version: *chrome_version
+
   # Send a notification to the specified web-hook URL (e.g. for Slack), if this is a non-PR build.
   # On PR builds, this is a no-op.
   notify_webhook_on_fail:
@@ -45,7 +59,15 @@ commands:
 jobs:
   setup:
     executor: action-executor
+    environment:
+      CHROMEDRIVER_VERSION: *chromedriver_version
     steps:
+      - run:
+          name: Log node/npm/yarn versions
+          command: |
+            echo "node : $(node --version)"
+            echo "npm  : v$(npm --version)"
+            echo "yarn : v$(yarn --version)"
       # Checkout, download and cache dependencies
       - checkout
       - restore_cache:
@@ -54,7 +76,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            CHROMEDRIVER_VERSION_ARG="--versions.chrome 75.0.3770.90" yarn install --network-timeout 100000 --frozen-lockfile
+            CHROMEDRIVER_VERSION_ARG="--versions.chrome $CHROMEDRIVER_VERSION" yarn install --network-timeout 100000 --frozen-lockfile
       - save_cache:
           name: Save Yarn Package Cache
           key: *cache_key
@@ -74,6 +96,7 @@ jobs:
     resource_class: xlarge
     parallelism: 4
     steps:
+      - install_chrome
       - attach_workspace:
           at: *working_directory
       # Switch `tsconfig.base.json` to the specified target.

--- a/infra/failing-projects.json
+++ b/infra/failing-projects.json
@@ -4,7 +4,6 @@
     "ng6-breadcrumbs-ngcc"
   ],
   "es5": [
-    "devextreme-angular-ngcc",
     "nativescript-angular-ngcc",
     "ng6-breadcrumbs-ngcc"
   ]


### PR DESCRIPTION
`@angular-devkit/build-angular` v0.1102.0-next.1 will require a Node.js version >= 12.13.0 ([package.json][1]). Previously, the docker image used on CI came with Node.js v12.9, which was causing Node.js engine incompatibility failures ([example failure][2]).

This commit updates the docker image used on CI to one that uses Node.js v14.15.4 (the latest LTS atm).

It also adds a step to log the versions of Node.js, npm and yarn for easier debugging.

[1]: https://github.com/angular/angular-devkit-build-angular-builds/blob/6d8121721f838668a7e1aa13ab9c01ae2b63e4e4/package.json#L128
[2]: https://circleci.com/gh/angular/ngcc-validation/24554