### PR TITLE
build: remove ignored/overriden packages from the ngcc standalone config

### DIFF
--- a/ngcc.config.standalone.js
+++ b/ngcc.config.standalone.js
@@ -5,23 +5,6 @@ module.exports = {
   packages: {
     ...baseConfig.packages,
 
-    // `@carbon/icons-angular` v11 (currently v11.0.0 and v11.0.1) has incorrect values for
-    // `package.json > main`, pointing to a non-existent file
-    // (`bundles/carbon-components-angular.js`) instead of the correct one:
-    // `bundles/carbon-icons-angular.umd.js`
-    //
-    // TODO: Remove this once https://github.com/carbon-design-system/carbon-icons-angular/issues/15
-    //       has been fixed.
-    '@carbon/icons-angular@>=11.0.0': {
-      entryPoints: {
-        '.': {
-          override: {
-            main: './bundles/carbon-icons-angular.umd.js',
-          },
-        },
-      },
-    },
-
     // `angular-draggable-droppable` uses Rollup with the
     // [rollup-commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs) plugin,
     // which results in UMD format that ngcc cannot understand. The Angular code is not contained

--- a/ngcc.config.standalone.js
+++ b/ngcc.config.standalone.js
@@ -5,16 +5,6 @@ module.exports = {
   packages: {
     ...baseConfig.packages,
 
-    // `@alfresco/adf-core` is currently failing with ngcc.
-    // Remove this when `@alfresco/adf-core` is removed from `infra/failing-projects.json`.
-    '@alfresco/adf-core': {
-      entryPoints: {
-        '.': {
-          ignore: true,
-        },
-      },
-    },
-
     // `@carbon/icons-angular` v11 (currently v11.0.0 and v11.0.1) has incorrect values for
     // `package.json > main`, pointing to a non-existent file
     // (`bundles/carbon-components-angular.js`) instead of the correct one:


### PR DESCRIPTION
See individual commits for details:
- [**build: remove `@alfresco/adf-core` from the list of ignored packages**](https://github.com/angular/ngcc-validation/pull/2550/commits/77fcf8b6e516afa8c19bc68ab4f4264ab08fc64d)
- [**build: stop overriding the `main` field of `@carbon/icons-angular`**](https://github.com/angular/ngcc-validation/pull/2550/commits/a7437e65c857edd57285b3352d76c8cf07727c0a)
