### PR TITLE
ci(renovate): limit PR concurrency to 2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "semanticCommits": true,
   "semanticCommitType": "build",
   "separateMajorMinor": false,
-  "prHourlyLimit": 2,
+  "prConcurrentLimit": 2,
   "timezone": "America/Tijuana",
   "rangeStrategy": "pin",
   "ignoreDeps": ["nativescript-angular"],


### PR DESCRIPTION
The way Renovate works when automerging is enabled causes many CI re-runs. (I.e. all open PRs have to be rebased once another PR has been merged.)

This commit limits the number of concurrent PRs to 2 to minimize the number of redundant CI re-runs. We are not setting the limit to 1, because that would mean that one failing PR would block all other updates until that PR is closed.

See also:
- [Docs on prConcurrentLimit][1].
- [Discussion][2] with more details on the problem and the available solutions.

[1]: https://docs.renovatebot.com/configuration-options/#prconcurrentlimit
[2]: https://github.com/renovatebot/renovate/discussions/8982