### PR TITLE
ci(renovate): update schedule to increase Renovate "working" hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
-  "extends": [
-    "schedule:nonOfficeHours"
+  "schedule": [
+    "before 7am every weekday",
+    "after 6pm every weekday",
+    "every weekend"
   ],
   "automerge": true,
   "major": {


### PR DESCRIPTION
Previously, Renovate was configured to use the [nonOfficeHours][1] schedule preset, which allows it to do work between 10pm and 5am on weekdays (and around the clock on weekends). Given recent changes to limit branch/PR concurrency to 2 (see [here][2] and #2650 for context), this does not allow Renovate to work through its backlog of updates fast enough.

This PR widens Renovate's "working" hours on weekdays from 7h to 13h (between 6pm and 7am) to allow it more time to catch up with its backlog, despite the limited concurrency.

[1]: https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours
[2]: https://github.com/renovatebot/renovate/discussions/8982