### PR TITLE
ci: configure Renovate to run on both `master` and the `latest` branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "baseBranches": ["master", "latest"],
   "schedule": [
     "before 7am every weekday",
     "after 6pm every weekday",
@@ -12,7 +13,7 @@
   "semanticCommits": true,
   "semanticCommitType": "build",
   "separateMajorMinor": false,
-  "prConcurrentLimit": 2,
+  "prConcurrentLimit": 3,
   "timezone": "America/Tijuana",
   "rangeStrategy": "pin",
   "ignoreDeps": ["nativescript-angular"],


### PR DESCRIPTION
This commit configures Renovate to run on the `latest` branch (in addition to `master`). The `latest` branch is for testing libraries against the `@latest` (i.e. stable) versions of Angular/CLI/Components.

The config is also updated to allow 3 concurrent PRs, since now Renovate will need to create PRs for 2 branches.