### PR TITLE
Revert "build(deps): update alfresco"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "private": true,
   "dependencies": {
     "@agm/core": "3.0.0-beta.0",
-    "@alfresco/adf-core": "4.4.0",
-    "@alfresco/adf-extensions": "4.4.0",
-    "@alfresco/js-api": "4.5.0",
+    "@alfresco/adf-core": "4.2.0",
+    "@alfresco/adf-extensions": "4.2.0",
+    "@alfresco/js-api": "4.3.0",
     "@angular-material-extensions/password-strength": "8.2.1",
     "@angular-redux/store": "10.0.0",
     "@angular/animations": "github:angular/animations-builds#3634d08d244e66b4c45828550e3c8a4010814840",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,25 +9,24 @@
   dependencies:
     tslib "^2.0.0"
 
-"@alfresco/adf-core@4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@alfresco/adf-core/-/adf-core-4.4.0.tgz#ca57ca77e26516ab51d918faabd5cea25db9757a"
-  integrity sha512-6E4mh+vH9o+c0K6tFhfaLZ1z8O+1YV7ctdZpzodWjU949g+uCRDsCalwAUHbD2/YmOTJTQTmODofibqOK7oGSw==
-  dependencies:
-    cropperjs "1.5.11"
-    tslib "^2.0.0"
-
-"@alfresco/adf-extensions@4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@alfresco/adf-extensions/-/adf-extensions-4.4.0.tgz#656ee9824a011d49d3b2d698fed0bae0dda52853"
-  integrity sha512-p/uuGK5MGM9JcLKvT8QgcCDm0Qy83opOXubKp55KB7U5w7ynlwcNiuKmZksotUEX2U/kfmbSi8NPLN1HDV5Z7w==
+"@alfresco/adf-core@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@alfresco/adf-core/-/adf-core-4.2.0.tgz#1c507ef5865f3a96e48e227e5941d58d76712710"
+  integrity sha512-6DIxhEhZ9VVqPrZyqMaHVFJ1xPRaQK7xMbfbN55RiX3Zv3WotQrZGE04xyVLv8aYQycZ/k+lNVopw3xq4RxMEw==
   dependencies:
     tslib "^2.0.0"
 
-"@alfresco/js-api@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@alfresco/js-api/-/js-api-4.5.0.tgz#51907830c87729823efb609248f8fe47557fcea0"
-  integrity sha512-Ovh4GlJMcVCgHHpYkzUvpaFPMdCUDGG7D02JrBXNWUxyh9ICdJhU7oFlofSeMnEBSBizvWyfnPbc7ZxVxnqbHw==
+"@alfresco/adf-extensions@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@alfresco/adf-extensions/-/adf-extensions-4.2.0.tgz#b36d2ab76ffa9677cfa56573270d782459e6b5d6"
+  integrity sha512-Vr2mvki22hUyuz9/048Z8L696MHEfwEeDlIVZTOq3gLtEaQ4WvMlZVbkT+JiZyNfqxjejX/S9XT/37bqf3vikw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@alfresco/js-api@4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@alfresco/js-api/-/js-api-4.3.0.tgz#b633cb8bbcba8dfccf85ceea2c2a60676e2fc378"
+  integrity sha512-Q/OeFqQ5uQWG2mGsXBbiG6CKh5MJvdL5h3mkcDqyFHMzZwM+URB082KOlL+6tQN5JgWegHgA3jGZE8EOPviQxw==
   dependencies:
     event-emitter "^0.3.5"
     minimatch "3.0.4"
@@ -7162,11 +7161,6 @@ critters@0.0.10:
     parse5 "^6.0.1"
     parse5-htmlparser2-tree-adapter "^6.0.1"
     pretty-bytes "^5.3.0"
-
-cropperjs@1.5.11:
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/cropperjs/-/cropperjs-1.5.11.tgz#502ae6d8ca098b124de6813601cca70015879fc0"
-  integrity sha512-SJUeBBhtNBnnn+UrLKluhFRIXLJn7XFPv8QN1j49X5t+BIMwkgvDev541f96bmu8Xe0TgCx3gON22KmY/VddaA==
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"


### PR DESCRIPTION
This reverts commit 764b7a7d6e3bf195c87c371c62bcb769283f3c8b.

`@alfresco/adf-core` v4.4.0 still relies on `SELECT_ITEM_HEIGHT_EM` exported by older versions of `@angular/material/select`. Since angular/components@99391e79391d20c6ef2f95a3ea4fd6901dcb631d, this constant is no longer exported by `@angular/material/select`. Therefore, we need to wait for a version of `@alfresco/adf-core` that is compatible with `@angular/material` v12.

Therefore, PR #3773 should have failed on CI and not be merged into master. For some reason, the [`setup` CI job][1] for that PR failed, but the PR was automatically merged by Renovate, subsequently causing [CI to fail][2] for master.

This PR reverts the change to fix master.

[1]: https://circleci.com/gh/angular/ngcc-validation/47844
[2]: https://app.circleci.com/pipelines/github/angular/ngcc-validation/10141/workflows/77ab9ebb-295c-4f17-98b5-cf4900a7f20f