### PR TITLE
ci: notify on Slack when `check-ngcc-packages` fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,8 @@ jobs:
           command: |
             CHROMEDRIVER_VERSION_ARG="--versions.chrome $CHROMEDRIVER_VERSION" yarn install --network-timeout 100000 --frozen-lockfile
       - run: yarn check-ngcc-packages
+      - notify_webhook_on_fail:
+          webhook_url_env_var: SLACK_NGCC_WEBHOOK_URL
       - save_cache:
           name: Save Yarn Package Cache
           key: *cache_key


### PR DESCRIPTION
Previously, the `setup` job did not include any tests (that could potentially fail). Since recently, however, in contains the `check-ngcc-packages` check, which can potentially fail and require user action to be resolved.

This commit updates the `setup` job to send a notification on Slack (as the other CI jobs do) whenever it fails, letting the team know that the might need to manually fix the issue (for example, for a PR to be merged).