### PR TITLE
build: fix renovate config after recent changes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "major": {
     "automerge": true
   },
+  "dependencyDashboard": true,
   "rebaseWhen": "conflicted",
   "semanticCommits": true,
   "semanticCommitType": "build",
@@ -151,6 +152,7 @@
         "minor",
         "major"
       ],
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
The renovate config is currently invalid JSON after the recent
changes in: db504daa46c4c7b0b9562648d2681e296cf99af5.