### PR TITLE
ci(Renovate): automatically update `browserslist` DB

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,13 @@
         "^@angular/flex-layout$",
         "^@angular/material"
       ],
+      "postUpgradeTasks": {
+        "commands": [
+          "yarn install",
+          "yarn run browserslist --update-db"
+        ],
+        "fileFilters": ["yarn.lock"]
+      },
       "groupName": "angular-framework-and-cli"
     },
     {


### PR DESCRIPTION
When `browserslist` is updated (as part of the Angular CLI updates) it often needs to also have the browsers DB updated. Failing to do so can result in built-time error like the foloowing ([example failure][1]):

```
BrowserslistError: Unknown version 101 of android
```

This commit avoids such errors by always updating the `browserslist` DB when updating the Angular CLI version.

[1]: https://circleci.com/gh/angular/ngcc-validation/105342